### PR TITLE
chore: Add validation for names input type in POST /hello endpoint

### DIFF
--- a/app/api.js
+++ b/app/api.js
@@ -42,4 +42,12 @@ describe('POST /hello', () => {
         expect(res.statusCode).toEqual(400);
         expect(res.text).toEqual('Error: No names provided');
     });
+
+    it('should return an error for invalid names input type', async () => {
+        const res = await request(app)
+            .post('/hello')
+            .send({ names: "Alice" }); // Ungültiger Typ, sollte ein Array sein
+        expect(res.statusCode).toEqual(400);
+        expect(res.text).toEqual('Error: Invalid input type for names');
+    });
 });


### PR DESCRIPTION
This pull request includes a change to the `app/api.js` file, specifically within the `describe('POST /hello', () => {` block. A new test has been added to validate the input type for names. This test ensures that if an invalid type is provided for the names input, the API will return a 400 error with an appropriate message.