### PR TITLE
chore: Add validation for names array in POST /hello endpoint

### DIFF
--- a/app/api.js
+++ b/app/api.js
@@ -42,4 +42,12 @@ describe('POST /hello', () => {
         expect(res.statusCode).toEqual(400);
         expect(res.text).toEqual('Error: No names provided');
     });
+
+    it('sollte einen Fehler zurückgeben, wenn Namen nicht als Array übergeben werden', async () => {
+        const res = await request(app)
+            .post('/hello')
+            .send({ names: 'Alice' }); // Namen nicht als Array
+        expect(res.statusCode).toEqual(400);
+        expect(res.text).toEqual('Error: Names must be provided as an array');
+    });
 });


### PR DESCRIPTION
This pull request includes a change to the `app/api.js` file, specifically within the `describe('POST /hello', () => {` block. The change adds a new test case to check if the server correctly responds with an error when the names are not provided as an array in the request body.